### PR TITLE
[Bug] Persistent Credentials from Authenticated Session

### DIFF
--- a/swat/commands/authenticate.py
+++ b/swat/commands/authenticate.py
@@ -23,6 +23,7 @@ class Command(BaseCommand):
             creds = pickle.loads(self.token.read_bytes())
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
+                return creds
         else:
             self.logger.info(f"Token file created: {self.token}")
         if not creds:
@@ -32,4 +33,4 @@ class Command(BaseCommand):
 
         self.token.write_bytes(pickle.dumps(creds))
 
-        return
+        return creds

--- a/swat/commands/base_command.py
+++ b/swat/commands/base_command.py
@@ -9,13 +9,14 @@ from typing import List
 
 class BaseCommand:
     def __init__(self, command: str = None, args: List[str] = [], credentials: Path = None,
-                 token: Path = None, config: dict = None) -> None:
+                 token: Path = None, config: dict = None, creds=None) -> None:
         self.command = command
         self.args = args
         self.config = config
         self.logger = logging.getLogger(__name__)
         self.credentials = credentials
         self.token = token
+        self.creds = creds  # Add this line
 
 
     def execute(self) -> None:

--- a/swat/commands/emulate.py
+++ b/swat/commands/emulate.py
@@ -18,6 +18,7 @@ class AttackData:
 class Command(BaseCommand):
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
+        self.kwargs = kwargs
         assert len(self.args) > 0, "No emulation command provided."
         self.attack = AttackData(self.args[0], self.args[1])
 
@@ -25,7 +26,7 @@ class Command(BaseCommand):
         try:
             attack_module = importlib.import_module(f"swat.commands.{attack.tactic}.{attack.technique}")
             command_module = getattr(attack_module, "Command")
-            return command_module()
+            return command_module(**self.kwargs)
         except (ImportError, AttributeError) as e:
             self.logger.error(f"Attack module {attack} not found.")
             return None

--- a/swat/shell.py
+++ b/swat/shell.py
@@ -30,6 +30,7 @@ class SWATShell(cmd.Cmd):
     def __init__(self, args: argparse.Namespace) -> None:
         super().__init__()
         self.args = args
+        self.creds = None
 
     def default(self, line: str) -> None:
         """Handle commands that are not recognized."""
@@ -37,7 +38,7 @@ class SWATShell(cmd.Cmd):
         command_name = args_list[0]
 
         # Create a new Namespace object containing the credentials and command arguments
-        new_args = dict(command=command_name, args=args_list[1:], config=CONFIG, **(vars(self.args)))
+        new_args = dict(command=command_name, args=args_list[1:], config=CONFIG, creds=self.creds, **(vars(self.args)))
 
         # Dynamically import the command module
         try:
@@ -55,13 +56,13 @@ class SWATShell(cmd.Cmd):
         try:
             # Instantiate and execute the command
             command = command_class(**new_args)
-            command.execute()
+            return command.execute() or None
         except AssertionError as e:
             logging.error(f"Error: {e}")
 
     def do_authenticate(self, arg: str) -> None:
         """Authenticate to the Google Workspace"""
-        self.default(f"authenticate {arg}")
+        self.creds = self.default(f"authenticate {arg}") # Store the authenticated credentials
 
     def do_coverage(self, arg: str) -> None:
         """Display ATT&CK coverage."""


### PR DESCRIPTION
## Summary
While the `authenticate` command can be used to authenticate to Google Workspace, it does not persistently carry this authenticated session and credentials throughout each module. As a result when an emulation module is executed, it is unable to authenticate with the correct service.

## Solution
* return valid `creds` from `authenticate.py`
* on `command.execute()` in the shell, store any return
* in `do_authenticate` store the result of the command execution and assign the creds to `self.creds`
* carry creds through `base_command.py` and `emulate.py` instantiation and inheritance