### PR TITLE
[Bug] Add Missing Scopes Variable for `authenticate.py`

### DIFF
--- a/swat/commands/authenticate.py
+++ b/swat/commands/authenticate.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
             self.logger.info(f"Token file created: {self.token}")
         if not creds:
             assert self.credentials.exists(), self.logger.error(f"Missing credentials file: {self.credentials}")
-            flow = InstalledAppFlow.from_client_secrets_file(str(self.credentials), scopes)
+            flow = InstalledAppFlow.from_client_secrets_file(str(self.credentials), self.config['google']['scopes'])
             creds = flow.run_local_server(port=0)
 
         self.token.write_bytes(pickle.dumps(creds))


### PR DESCRIPTION
## Summary
`scopes` is referenced in the `authenticate.py` file, however, it should be `self.config['google']['scopes']`. The scopes need to load from the config file.

This bug will occur if the `token.pickle` or `token.json` files are removed and OAuth consent is then necessary for the tool.