### PR TITLE
[Enhancement] Add `clear` Command to Clear Terminal

### DIFF
--- a/swat/shell.py
+++ b/swat/shell.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from swat import utils
 from swat.commands.base_command import BaseCommand
+from .utils import clear_terminal
 
 ROOT_DIR = Path(__file__).parent.parent.absolute()
 DEFAULT_TOKEN_FILE = ROOT_DIR / "token.pickle"
@@ -38,7 +39,7 @@ class SWATShell(cmd.Cmd):
         command_name = args_list[0]
 
         # Create a new Namespace object containing the credentials and command arguments
-        new_args = dict(command=command_name, args=args_list[1:], 
+        new_args = dict(command=command_name, args=args_list[1:],
                         config=CONFIG, creds=self.creds, **(vars(self.args)))
 
         # Dynamically import the command module
@@ -76,6 +77,10 @@ class SWATShell(cmd.Cmd):
     def do_data(self, arg: str) -> None:
         """Display Google Workspace data."""
         self.default(f"data {arg}")
+
+    def do_clear(self, arg: None) -> None:
+        """Clear the screen."""
+        clear_terminal()
 
     def do_exit(self, arg: str) -> bool:
         """Exit the shell."""

--- a/swat/utils.py
+++ b/swat/utils.py
@@ -1,10 +1,10 @@
 
+import json
+import os
 from pathlib import Path
 from typing import Union
 
-import json
 import yaml
-
 
 ROOT_DIR = Path(__file__).parent.parent.absolute()
 ETC_DIR = ROOT_DIR / "swat" / "etc"
@@ -20,3 +20,8 @@ def load_etc_file(filename: str) -> Union[str, dict]:
         return json.loads(contents)
     elif path.suffix in (".yaml", ".yml"):
         return yaml.safe_load(contents)
+
+
+def clear_terminal():
+    """Clear the terminal."""
+    _ = os.system('cls||clear')


### PR DESCRIPTION
## Related PRs
* https://github.com/elastic/SWAT/pull/12

## Overview
This pull request adds `clear` as a base command. The `clear` command will clear the terminal console output using `cls` or `clear`. Both are attempted to cover macOS, Linux and Windows. This work derives from [PR #12](https://github.com/elastic/SWAT/pull/12) by @seth-goodwin .

