### PR TITLE
[Enhancement] Adjust `print` statements and add emulation logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ venv.bak/
 *.cred_store.json
 
 # Logging
+logs/
 logs/*
 *.log
 

--- a/swat/attack.py
+++ b/swat/attack.py
@@ -1,6 +1,7 @@
 
 import gzip
 import json
+import logging
 from functools import lru_cache
 from typing import Optional
 
@@ -30,7 +31,7 @@ def download_attack_data(save: bool = True) -> (Optional[dict], Optional[bytes])
     latest_version = Version.parse(get_version_from_tag(release_name), optional_minor_and_patch=True)
 
     if current_version and current_version >= latest_version:
-        print(f'No versions newer than the current detected: {current_version}')
+        logging.info(f'ATT&CK version: {current_version} is up to date.')
         return None, None
 
     download = f'https://raw.githubusercontent.com/mitre/cti/{release_name}/enterprise-attack/enterprise-attack.json'
@@ -42,7 +43,7 @@ def download_attack_data(save: bool = True) -> (Optional[dict], Optional[bytes])
 
     if save:
         ATTACK_PATH.write_bytes(compressed)
-        print(f'ATT&CK version: {latest_version} saved to: {ATTACK_PATH}')
+        logging.info(f'ATT&CK version: {latest_version} saved to: {ATTACK_PATH}')
 
     return attack_data, compressed
 

--- a/swat/base.py
+++ b/swat/base.py
@@ -1,5 +1,6 @@
 
 import dataclasses
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Literal, Union
@@ -107,11 +108,11 @@ class CredStore:
     @classmethod
     def from_file(cls, file: Path = DEFAULT_CRED_STORE_FILE) -> Optional['CredStore']:
         if file.exists():
-            print(f"Loaded cred store dump from: {file}")
+            logging.info(f"Loaded cred store dump from: {file}")
             return cls(**json.loads(file.read_text()))
 
     def save(self):
-        print(f"Saved cred store to {self.path}")
+        logging.info(f"Saved cred store to {self.path}")
         self.path.write_text(json.dumps(dataclasses.asdict(self), indent=2, sort_keys=True, cls=PathlibEncoder))
 
     def add(self, key: str, config: Optional[CRED_CONFIG_TYPES] = None, session: Optional[Credentials] = None,

--- a/swat/commands/coverage.py
+++ b/swat/commands/coverage.py
@@ -53,13 +53,13 @@ class Command(BaseCommand):
     @staticmethod
     def version() -> None:
         """Show the ATT&CK version."""
-        print(f"ATT&CK version: {load_attack_data()['version']}")
+        self.logger.info(f"ATT&CK version: {load_attack_data()['version']}")
 
     def view(self) -> None:
         """View coverage details."""
         entries = self.build_table_entries()
         if not entries:
-            print("No results found.")
+            self.logger("No results found.")
         else:
             col_widths = [None, None, None, 50, None, 50]
             print(tabulate(entries, headers="keys", maxcolwidths=col_widths, tablefmt="fancy_grid"))

--- a/swat/commands/emulate.py
+++ b/swat/commands/emulate.py
@@ -54,12 +54,12 @@ class Command(BaseCommand):
             command_module = importlib.import_module(f"swat.emulations.{dotted_command}")
             command_class = getattr(command_module, "Emulation")
         except (ImportError, AttributeError) as e:
-            print(f"Error: Command '{name}' not found.")
+            self.logger.info(f"Error: Command '{name}' not found.")
             return
 
         # Check if the command class is a subclass of BaseCommand
         if not issubclass(command_class, BaseEmulation):
-            print(f"Error: Command '{name}' is not a valid command.")
+            self.logger.info(f"Error: Command '{name}' is not a valid command.")
             return
 
         return command_class
@@ -73,5 +73,5 @@ class Command(BaseCommand):
         if not self.emulation_command:
             self.logger.info(f"Available commands: " + '|'.join(self.get_emulate_commands()))
         else:
-            self.logger.info(f"Executing command: {self.emulation_name}")
+            self.logger.info(f"Executing emulation: {self.emulation_name}")
             self.emulation_command.execute()

--- a/swat/emulations/base_emulation.py
+++ b/swat/emulations/base_emulation.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from ..attack import lookup_technique_by_id
 from ..base import SWAT
+from ..logger import configure_emulation_logger
 from ..misc import get_custom_argparse_formatter, validate_args
 
 
@@ -55,6 +56,8 @@ class BaseEmulation:
     def __init__(self, args: list, obj: SWAT, **extra) -> None:
         self.obj = obj
         self.logger = logging.getLogger(__name__)
+        emulation_name = ".".join(self.__module__.split(".")[2:])
+        self.elogger = configure_emulation_logger(emulation_name, obj.config)
         self.attack_data = self.get_attack()
 
         assert self.parser, "'parser' must be implemented in each emulation command class"

--- a/swat/emulations/persistence/add_roles.py
+++ b/swat/emulations/persistence/add_roles.py
@@ -6,7 +6,7 @@ class Emulation(BaseEmulation):
 
     parser = BaseEmulation.load_parser(description='Account Manipulation: Additional Cloud Roles')
     parser.add_argument('--username', required=True, help='Username to add the role to')
-    parser.add_argument('--roles', required=True, nargs=-1, help='Roles to add')
+    parser.add_argument('--roles', required=True, help='Roles to add')
 
     techniques = ["T1098.003"]
 
@@ -14,5 +14,5 @@ class Emulation(BaseEmulation):
         super().__init__(**kwargs)
 
     def execute(self) -> None:
-        self.logger.info(self.exec_str(self.parser.description))
-        self.logger.info("Hello, world, from T1098!")
+        self.elogger.info(self.exec_str(self.parser.description))
+        self.elogger.info("Hello, world, from T1098!")

--- a/swat/etc/config.yaml
+++ b/swat/etc/config.yaml
@@ -24,6 +24,5 @@ logging:
   level: info
   format: text
   output: stdout
-  path: swat.log
   log_file_format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s (%(filename)s:%(lineno)d)"
   log_console_format: "%(asctime)s - %(message)s"

--- a/swat/logger.py
+++ b/swat/logger.py
@@ -1,8 +1,10 @@
 
 import logging
+from pathlib import Path
 
 from colorama import Fore, Style
 
+DEFAULT_LOGGING_PATH = Path.cwd() / "logs"
 
 def configure_logging(config: dict = None, level: int = logging.INFO) -> None:
     """Logging for the entire application."""
@@ -31,7 +33,8 @@ def configure_logging(config: dict = None, level: int = logging.INFO) -> None:
     console_handler.setFormatter(CustomFormatter())
 
     # Set up file handler
-    log_file = config['logging']['path']
+    DEFAULT_LOGGING_PATH .mkdir(exist_ok=True)
+    log_file = DEFAULT_LOGGING_PATH / "swat.log"
     file_handler = logging.FileHandler(log_file)
     file_handler.setLevel(level)
     file_handler.setFormatter(logging.Formatter(log_file_format))
@@ -41,3 +44,23 @@ def configure_logging(config: dict = None, level: int = logging.INFO) -> None:
     logger.setLevel(level)
     logger.addHandler(console_handler)
     logger.addHandler(file_handler)
+
+def configure_emulation_logger(emulation_name: str, config: dict, level: int = logging.INFO) -> logging.Logger:
+    """Logging for a specific emulation."""
+    elogger = logging.getLogger(f"{emulation_name}")
+
+    # Ensure 'logs' directory exists
+    DEFAULT_LOGGING_PATH.mkdir(exist_ok=True)
+
+    # Create file handler for the emulation-specific log file
+    tactic, playbook = emulation_name.split('.')
+    log_file = DEFAULT_LOGGING_PATH / f"{tactic}_{playbook}.log"
+    file_handler = logging.FileHandler(log_file)
+    file_handler.setLevel(level)
+    log_file_format = config['logging']['log_file_format']
+    file_handler.setFormatter(logging.Formatter(log_file_format))
+
+    # Add the file handler to the emulation logger
+    elogger.addHandler(file_handler)
+
+    return elogger

--- a/swat/shell.py
+++ b/swat/shell.py
@@ -95,9 +95,9 @@ class SWATShell(cmd.Cmd):
             if method:
                 # if the do_ method exists, print its docstring
                 if method.__doc__ is not None:
-                    print(f"{method.__doc__}\n")
+                    logging.info(f"{method.__doc__}\n")
                 else:
-                    print(f"{self.nohelp % arg}\n")
+                    logging.info(f"{self.nohelp % arg}\n")
             else:
                 # load commands dynamically and get help based on the following precedence:
                 #   1. custom_help() method defined in the command class
@@ -117,9 +117,9 @@ class SWATShell(cmd.Cmd):
                             command_class = EmulateCommand.load_emulation_class(emulation)
                         except AssertionError as e:
                             raise AssertionError(f"Emulation '{emulation}': {e}.")
-                        print(f"[{command_class.get_attack()}]\n{command_class.help()}")
+                        logging.info(f"[{command_class.get_attack()}]\n{command_class.help()}")
                     else:
-                        print(f"Unrecognized emulation: {emulation}, options: "
+                        logging.info(f"Unrecognized emulation: {emulation}, options: "
                               f"{'|'.join(EmulateCommand.get_emulate_commands())}\n")
 
                 elif arg in commands:
@@ -133,7 +133,7 @@ class SWATShell(cmd.Cmd):
                     parser: argparse.ArgumentParser = getattr(command_class, "parser", None)
 
                     if custom:
-                        print(f"{custom}\n")
+                        logging.info(f"{custom}\n")
                     elif parser:
                         subparsers = utils.load_subparsers(parser)
                         if remaining and remaining[0] in subparsers:
@@ -145,18 +145,18 @@ class SWATShell(cmd.Cmd):
                             parser.print_help()
                             print()
                     elif command_class.__doc__ is not None:
-                        print(f"{command_class.__doc__}\n")
+                        logging.info(f"{command_class.__doc__}\n")
                     else:
-                        print(f"{self.nohelp % arg}\n")
+                        logging.info(f"{self.nohelp % arg}\n")
                 else:
-                    print(f"unrecognized command: {arg}")
-                    print(f"{self.doc_leader}\n")
+                    logging.info(f"unrecognized command: {arg}")
+                    logging.info(f"{self.doc_leader}\n")
                     self.print_topics(self.doc_header, all_cmds, 15, 80)
             return
         else:
             # print a unified, sorted list of do_ and imported commands
             # this drops support for help_* topics
-            print(f"{self.doc_leader}\n")
+            logging.info(f"{self.doc_leader}\n")
             self.print_topics(self.doc_header, all_cmds, 15, 80)
 
     def emptyline(self) -> None:
@@ -170,6 +170,7 @@ class SWATShell(cmd.Cmd):
 
         # Create a new Namespace object containing the credentials and command arguments
         self._new_args = dict(command=self._command_name, args=args)
+        logging.info(f"Command execution: {self._new_args}")
         return line
 
     def postcmd(self, stop: bool, line: str) -> bool:


### PR DESCRIPTION
## Overview
This PR adjusts `print` statements where applicable to the logger. It also adds `logs/` as the folder where all logs live. In here is the base `swat.log`. 

Also added separate emulation module logging and log files. This logger is added to the handlers during base_emulation and therefore inherited into each emulation module as `self.elogger`. With this, it will also log to the `swat.log` file and its own `TACTIC_MODULENAME.log` file.

<img width="2457" alt="Screenshot 2023-08-05 at 1 06 40 PM" src="https://github.com/elastic/SWAT/assets/99630311/b9d493a6-0dfc-4b2d-bd16-f08daaf85068">
