### PR TITLE
[Feature Request] Add emulation configuration inheritance through `base_emulation.py`

### DIFF
--- a/swat/emulations/base_emulation.py
+++ b/swat/emulations/base_emulation.py
@@ -95,6 +95,7 @@ class BaseEmulation:
         '''Return custom parser.'''
         return get_custom_argparse_formatter(*args, **kwargs)
 
+    @classmethod
     def load_emulation_config(self) -> Optional[dict]:
         '''Load YAML config file for emulation.'''
         # Determine the path to the corresponding YAML file


### PR DESCRIPTION
## Overview
This PR adds the option to add an emulation config via the same name as the module .py file. For example, `add_roles.py` would have `add_roles.yaml` in the same directory. In `BaseEmulation` class, a workflow now exists to find a config for the same emulation and if found, load it into the `BaseEmulation` object which is then inherited into every emulation module and therefore accessible.

<img width="1402" alt="Screenshot 2023-08-05 at 2 43 14 PM" src="https://github.com/elastic/SWAT/assets/99630311/12545238-b7a1-4678-a0b8-7b7ba92801b2">
