### PR TITLE
[Enhancement] Adjust auth and cred naming, dataclasses and calls

### DIFF
--- a/swat/commands/creds.py
+++ b/swat/commands/creds.py
@@ -7,55 +7,55 @@ from ..misc import validate_args
 
 
 class Command(BaseCommand):
-    parser = BaseCommand.load_parser(description='SWAT credential config management.')
+    parser = BaseCommand.load_parser(description='SWAT credentials management.')
     subparsers = parser.add_subparsers(dest='subcommand', title='subcommands', required=True)
 
-    parser_add = subparsers.add_parser('add', description='Load credential config to the cred store',
-                                       help='Load credential config to the cred store')
+    parser_add = subparsers.add_parser('add', description='Add credentials to the cred store',
+                                       help='Add credentials to the cred store')
     parser_add.add_argument('key', help='Name of key to store the creds under')
-    parser_add.add_argument('config', type=Path, help='Path to the credentials config file')
-    parser_add.add_argument('--service-account', action='store_true', help='Service account credential config')
+    parser_add.add_argument('creds', type=Path, help='Path to the credentials file')
+    parser_add.add_argument('--service-account', action='store_true', help='Service account credentials')
     parser_add.add_argument('--override', action='store_true', help='Override an existing store')
 
-    parser_remove = subparsers.add_parser('remove', description='Remove credential config from the cred store',
-                                          help='Remove credential config from the cred store')
+    parser_remove = subparsers.add_parser('remove', description='Remove credentials from the cred store',
+                                          help='Remove credentials from the cred store')
     parser_remove.add_argument('key', help='Name of key to remove from the creds store')
 
-    parser_list = subparsers.add_parser('list', description='List credential configs within the cred store',
-                                        help='List credential configs within the cred store')
+    parser_list = subparsers.add_parser('list', description='List credentials within the cred store',
+                                        help='List credentials within the cred store')
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
         self.parser_add.set_defaults(func=self.add_creds)
         self.parser_remove.set_defaults(func=self.remove_creds)
-        self.parser_list.set_defaults(func=self.list_configs)
+        self.parser_list.set_defaults(func=self.list_credentials)
 
         self.args = validate_args(self.parser, self.args)
 
     def add_creds(self):
-        assert self.args.config.exists(), f'Credentials config file not found: {self.args.config}'
+        assert self.args.creds.exists(), f'Credentials file not found: {self.args.creds}'
 
         try:
             if self.args.service_account:
-                config = ServiceAccountCreds.from_file(self.args.config)
+                creds = ServiceAccountCreds.from_file(self.args.creds)
             else:
-                config = OAuthCreds.from_file(self.args.config) if self.args.config else None
+                creds = OAuthCreds.from_file(self.args.creds) if self.args.creds else None
 
-            self.obj.cred_store.add(self.args.key, config=config, override=self.args.override)
-            self.logger.info(f'Credentials config added with key: {self.args.key}')
+            self.obj.cred_store.add(self.args.key, creds=creds, override=self.args.override)
+            self.logger.info(f'Credentials added with key: {self.args.key}')
         except TypeError as e:
-            self.logger.info(f'Invalid credentials config file: {self.args.config} - {e}')
+            self.logger.info(f'Invalid credentials file: {self.args.creds} - {e}')
 
     def remove_creds(self):
         removed = self.obj.cred_store.remove(self.args.key)
         if removed:
-            self.logger.info(f'Removed credentials config with key: {self.args.key}')
+            self.logger.info(f'Removed credentials with key: {self.args.key}')
         else:
-            self.logger.info(f'No credentials config found with key: {self.args.key}')
+            self.logger.info(f'No credentials found with key: {self.args.key}')
 
-    def list_configs(self):
-        cred_configs = self.obj.cred_store.list_configs()
-        self.logger.info(f'Stored credential configs: {", ".join(cred_configs) if cred_configs else None}')
+    def list_credentials(self):
+        creds = self.obj.cred_store.list_credentials()
+        self.logger.info(f'Stored credentials: {", ".join(creds) if creds else None}')
 
     def execute(self) -> None:
         self.args.func()


### PR DESCRIPTION
## Overview
This PR adjusts some of the naming, dataclass values, and credential calls regarding `base.py`, `auth.py`, and `creds.py`. This PR is meant to be make changes that are more aligned with Google oauth, service accounts and credential naming in general.

<img width="787" alt="Screenshot 2023-08-05 at 5 25 29 PM" src="https://github.com/elastic/SWAT/assets/99630311/0380cb97-24f3-4023-99e3-a79629ae4be4">
<img width="993" alt="Screenshot 2023-08-05 at 5 24 15 PM" src="https://github.com/elastic/SWAT/assets/99630311/4ed2ab3c-55e8-44c1-a999-bf4dda2102d9">
<img width="1134" alt="Screenshot 2023-08-05 at 5 35 53 PM" src="https://github.com/elastic/SWAT/assets/99630311/fb26a740-2244-4f53-87b1-7e59f788dc3e">
<img width="1134" alt="Screenshot 2023-08-05 at 5 35 53 PM" src="https://github.com/elastic/SWAT/assets/99630311/6f7323e4-714e-4708-ab28-8d186fff4d3d">


As shown in the images, credentials will now be saved to the credential store with their key name and when listed will show the `google.oauth2` objects `service_account` or `credentials` followed by the `client_id` which is always consistent and will help the user locate which specific client these credentials are for.


I made sure to test that the saved session would work fine when interacting with APIs as well using the audit command.
<img width="1268" alt="Screenshot 2023-08-05 at 5 37 06 PM" src="https://github.com/elastic/SWAT/assets/99630311/734a2967-0cef-4356-ad36-19c3df96c9f5">

