### PR TITLE
[Bug] Expose auth in emulations and adjust auth/cred commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ venv.bak/
 *token.pickle
 *.pem
 *credentials.json
+*.json
 /credentials
 /credentials/*
 *.cred_store.json

--- a/swat/commands/audit.py
+++ b/swat/commands/audit.py
@@ -91,7 +91,7 @@ class Command(BaseCommand):
 
         # Check if the session exists in the credential store
         if self.obj.cred_store.store.get('default') is None:
-            self.logger.error(f'Please authenticate with "auth session --default --config" before running this command.')
+            self.logger.error(f'Please authenticate with "auth session --default --creds" before running this command.')
             return
 
         try:

--- a/swat/commands/auth.py
+++ b/swat/commands/auth.py
@@ -8,6 +8,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from ..commands.base_command import BaseCommand
 from ..utils import ROOT_DIR, check_file_exists
 from ..misc import validate_args
+from ..base import ServiceAccountCreds, OAuthCreds
 
 DEFAULT_TOKEN_FILE = ROOT_DIR / 'token.pkl'
 
@@ -19,11 +20,10 @@ class Command(BaseCommand):
 
     parser_session = subparsers.add_parser('session', description='Authenticate with Google Workspace (default oauth)',
                                            help='Authenticate with Google Workspace (default oauth)')
-    parser_session.add_argument('--default', action='store_true', help='Store the credentials as default')
     parser_session.add_argument('--key', help='Name of key to store the creds under')
     parser_session.add_argument('--creds', type=Path, help='Path to the credentials file')
     parser_session.add_argument('--service-account', action='store_true', help='Authenticate a service account')
-
+    parser_session.add_argument('--store', type=str, help='Add authenticated session to credential store with key')
     parser_list = subparsers.add_parser('list', description='List credential sessions within the cred store',
                                         help='List credential sessions within the cred store')
 
@@ -45,7 +45,7 @@ class Command(BaseCommand):
                 session = cred.refreshed_session()
             else:
                 if self.args.service_account:
-                    session = Credentials.from_service_acccount_info(cred.creds.to_dict())
+                    session = Credentials.from_service_account_info(cred.creds.to_dict())
                 else:
                     flow = InstalledAppFlow.from_client_config(cred.creds.to_dict(), self.obj.config['google']['scopes'])
                     session = flow.run_local_server(port=0)
@@ -60,14 +60,25 @@ class Command(BaseCommand):
                 check_file_exists(self.args.creds, f'Missing OAuth2.0 credentials file: {self.args.creds}')
                 flow = InstalledAppFlow.from_client_secrets_file(str(self.args.creds), self.obj.config['google']['scopes'])
                 session = flow.run_local_server(port=0)
-            if self.args.default:
-                self.obj.cred_store.add('default', creds=self.args.creds, override=True, session=session)
         else:
             self.logger.info(f'Missing key or credentials file.')
             return None
 
         self.logger.info(f'Authenticated successfully.' if session else f'Failed to authenticate.')
+        if self.args.store:
+            type = 'service' if self.args.service_account else 'oauth'
+            self.obj.cred_store.add(self.args.store, creds=self.args.creds, session=session, type=type)
         return session
+
+    @staticmethod
+    def get_auth_session(creds: dict, type: str, scopes: list) -> Optional[Credentials]:
+        '''Get an authenticated session from a credentials dict.'''
+        assert type in ('oauth', 'service'), f'Invalid type: {type}, expected "oauth" or "service"'
+        if type == 'oauth':
+            flow = InstalledAppFlow.from_client_config(creds, scopes=scopes)
+            return flow.run_local_server(port=0)
+        else:
+            return Credentials.from_service_account_info(creds)
 
     def list_sessions(self):
         cred_sessions = self.obj.cred_store.list_sessions()


### PR DESCRIPTION
## Overview
There were a couple of bugs and design changes that were made after testing emulations and the `auth` and `creds` commands.

#### Issue: Sessions not available after credential storage from within emulations
When running an emulation, credentials were available in the credential store, but an active session is needed to start a service client. However, `authenticate` in `auth.py` was a `Command` method and thus not available from emulations. To solve this, a static method was added that will take credentials and authenticate as normal, returning a session that can be used in the emulation.

Below is an example, where `default` contains service account credentials in the store. We pass it to `get_auth_session` and it returns an actual session.

```python 
class Emulation(BaseEmulation):

    parser = BaseEmulation.load_parser(description='Account Manipulation: Additional Cloud Roles')
    parser.add_argument('--username', required=True, help='Username to add the role to')
    parser.add_argument('--roles', required=True, help='Roles to add')

    techniques = ['T1098.003']

    def __init__(self, **kwargs) -> None:
        super().__init__(**kwargs)
        self.session = AuthCommand.get_auth_session(creds=self.obj.cred_store.store['default'].creds.to_dict(), type='service')
        self.service = build('drive', 'v3', credentials=self.session)

    def execute(self) -> None:
        self.elogger.info(self.exec_str(self.parser.description))
```

#### `auth` command does not store the sessions, only the credentials by default in the credential store.
If users would prefer to store both the credentials and session after authentication, they can now use `--store NAME` and it will store those credentials and session in the credential store. This allows us to authenticate -> store credentials -> store session -> access in emulations.

#### `PosixPath` stored in credential store
Originally, if `auth` was used to authenticate, the path of the credentials was being stored as `creds` in the credential store. This has been adjusted to determine if it is a `Path` and if so, load it `from_file` with `OAuthCreds` or `ServiceAccountCreds` and save it as the actual JSON object.
