### PR TITLE
[Documentation] Add `CHANGELOG` File for Tracking Changes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,11 @@ Support
 
 Encountering issues? Reach out! Initiate a `discussion <https://github.com/elastic/SWAT/discussions>`_ on our GitHub repository.
 
+Stay Updated
+============
+
+Stay updated about SWAT's latest developments by visiting our `CHANGELOG <https://swat.readthedocs.io/en/latest/changelog.html>`_.
+
 Disclaimer
 ==========
 

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -1,0 +1,19 @@
+Changelog
+=========
+
+All notable changes to this project will be documented in this file.
+
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_.
+
+Current (Unreleased)
+--------------------
+
+- Initial start of the changelog documentation. [`@terrancedejesus <https://github.com/terrancedejesus>`_]
+
+[0.0.1] - 2023-08-12
+--------------------------
+
+Added
+^^^^^
+
+- Initial release. [`@terrancedejesus <https://github.com/terrancedejesus>`_, `@br0k3ns0und <https://github.com/brokensound77>`_]

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -79,6 +79,11 @@ Support
 
 Encountering issues? Reach out! Initiate a `discussion <https://github.com/elastic/SWAT/discussions>`_ on our GitHub repository.
 
+Stay Updated
+============
+
+Stay updated about SWAT's latest developments by visiting our `CHANGELOG <https://swat.readthedocs.io/en/latest/changelog.html>`_.
+
 Disclaimer
 ==========
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ Contents:
    how_to_guides
    contributing
    developers
+   CHANGELOG
 
 
 Indices and tables


### PR DESCRIPTION
## Overview
Adds a `CHANGELOG.rst` file to `docs/` to track development of SWAT. Updates `README.rst` to add a `Stay Updated` section that points to the changelog.