### PR TITLE
[Feature Request] Add `pytest` and emulation metadata testing

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - dev
 
 jobs:
   test:

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.10
 

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -1,0 +1,27 @@
+name: Run pytest
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.10
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install poetry
+        poetry install
+
+    - name: Run tests
+      run: poetry run pytest tests/

--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.10
+        python-version: 3.10.x
 
     - name: Install dependencies
       run: |

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -9,6 +9,8 @@ Current (Unreleased)
 --------------------
 
 - Initial start of the changelog documentation. [`@terrancedejesus <https://github.com/terrancedejesus>`_]
+- Added `pytest` to the project. [`@terrancedejesus <https://github.com/terrancedejesus>`_]
+- Added `test_emulation.py` test file with several test cases for emulation metadata. [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 
 [0.0.1] - 2023-08-12
 --------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pandas = { version = "2.0.2", optional = true }
 selenium = "^4.11.2"
 sphinx = "^7.2.2"
 sphinx-rtd-theme = "^1.3.0"
+pytest = "^7.4.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 description = "Simple Workspace Attack Tool for emulating against Google Workspace environments."
 authors = ["Terrance DeJesus <contact@dejesus.io>"]
 license = "Apache-2.0"
-readme = "README.md"
+readme = "README.rst"
 homepage = "https://github.com/elastic/SWAT"
 repository = "https://github.com/elastic/SWAT"
 documentation = "https://github.com/elastic/SWAT/wiki"
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Topic :: Security",
     "Topic :: Google Workspace",

--- a/tests/test_emulations.py
+++ b/tests/test_emulations.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import List, Type
 
 import pytest
 
@@ -8,37 +9,42 @@ from swat.emulations.base_emulation import BaseEmulation
 
 
 class TestEmulations:
-    """Tests for emulations."""
+    """Test class for emulations."""
 
-    @pytest.fixture(scope="class", autouse=True)
-    def emulations(self):
+    @staticmethod
+    def get_all_emulation_classes() -> List[Type[BaseEmulation]]:
+        """Fetch all emulation classes."""
+
         return emulate_command().load_all_emulation_classes()
 
-    def test_techniques(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no techniques defined' for emulation in emulations if not hasattr(emulation, 'techniques')]
-        assert not errors, '\n'.join(errors)
+    emulations_list = get_all_emulation_classes.__func__()
 
-    def test_services(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no services defined' for emulation in emulations if not hasattr(emulation, 'services')]
-        assert not errors, '\n'.join(errors)
+    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
+    def test_inheritance(self, emulation: Type[BaseEmulation]):
+        """Test if emulation inherits from BaseEmulation."""
+        assert issubclass(emulation, BaseEmulation), f'Emulation "{emulation.name}" does not inherit from BaseEmulation'
 
-    def test_name(self, emulations):
-        errors = [f'Emulation "{emulation}" has no name defined' for emulation in emulations if not hasattr(emulation, 'name')]
-        assert not errors, '\n'.join(errors)
+    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
+    def test_parser_defined(self, emulation: Type[BaseEmulation]):
+        """Test if parser is defined in emulation."""
+        assert hasattr(emulation, 'parser'), f'Emulation "{emulation.name}" has no parser defined'
 
-    def test_scopes(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no scopes defined' for emulation in emulations if not hasattr(emulation, 'scopes')]
-        assert not errors, '\n'.join(errors)
+    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
+    def test_services_defined(self, emulation: Type[BaseEmulation]):
+        """Test if services are defined in emulation."""
+        assert hasattr(emulation, 'services'), f'Emulation "{emulation.name}" has no services defined'
 
-    def test_parser(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no parser defined' for emulation in emulations if not hasattr(emulation, 'parser')]
-        assert not errors, '\n'.join(errors)
+    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
+    def test_scopes_defined(self, emulation: Type[BaseEmulation]):
+        """Test if scopes are defined in emulation."""
+        assert hasattr(emulation, 'scopes'), f'Emulation "{emulation.name}" has no scopes defined'
 
-    def test_execute(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no execute method defined' for emulation in emulations if not hasattr(emulation, 'execute')]
-        assert not errors, '\n'.join(errors)
+    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
+    def test_techniques_defined(self, emulation: Type[BaseEmulation]):
+        """Test if techniques are defined in emulation."""
+        assert hasattr(emulation, 'techniques'), f'Emulation "{emulation.name}" has no techniques defined'
 
-    def test_cleanup(self, emulations):
-        warn_msgs = [f'Emulation "{emulation.__module__}" has no cleanup method defined' for emulation in emulations if not hasattr(emulation, 'cleanup')]
-        for msg in warn_msgs:
-            warnings.warn(msg)
+    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
+    def test_execute_method_defined(self, emulation: Type[BaseEmulation]):
+        """Test if execute method is defined in emulation."""
+        assert hasattr(emulation, 'execute'), f'Emulation "{emulation.name}" has no execute method defined'

--- a/tests/test_emulations.py
+++ b/tests/test_emulations.py
@@ -19,32 +19,18 @@ class TestEmulations:
 
     emulations_list = get_all_emulation_classes.__func__()
 
-    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
-    def test_inheritance(self, emulation: Type[BaseEmulation]):
-        """Test if emulation inherits from BaseEmulation."""
-        assert issubclass(emulation, BaseEmulation), f'Emulation "{emulation.name}" does not inherit from BaseEmulation'
+    required_attributes = [
+        ("name", "has no name defined"),
+        ("parser", "has no parser defined"),
+        ("services", "has no services defined"),
+        ("scopes", "has no scopes defined"),
+        ("techniques", "has no techniques defined"),
+        ("execute", "has no execute method defined"),
+    ]
 
     @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
-    def test_parser_defined(self, emulation: Type[BaseEmulation]):
-        """Test if parser is defined in emulation."""
-        assert hasattr(emulation, 'parser'), f'Emulation "{emulation.name}" has no parser defined'
+    @pytest.mark.parametrize("attribute, error_msg", required_attributes)
+    def test_required_attributes(self, emulation: Type[BaseEmulation], attribute: str, error_msg: str):
+        """Test if required attributes are defined in emulation."""
 
-    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
-    def test_services_defined(self, emulation: Type[BaseEmulation]):
-        """Test if services are defined in emulation."""
-        assert hasattr(emulation, 'services'), f'Emulation "{emulation.name}" has no services defined'
-
-    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
-    def test_scopes_defined(self, emulation: Type[BaseEmulation]):
-        """Test if scopes are defined in emulation."""
-        assert hasattr(emulation, 'scopes'), f'Emulation "{emulation.name}" has no scopes defined'
-
-    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
-    def test_techniques_defined(self, emulation: Type[BaseEmulation]):
-        """Test if techniques are defined in emulation."""
-        assert hasattr(emulation, 'techniques'), f'Emulation "{emulation.name}" has no techniques defined'
-
-    @pytest.mark.parametrize("emulation", emulations_list, ids=lambda e: e.name)
-    def test_execute_method_defined(self, emulation: Type[BaseEmulation]):
-        """Test if execute method is defined in emulation."""
-        assert hasattr(emulation, 'execute'), f'Emulation "{emulation.name}" has no execute method defined'
+        assert hasattr(emulation, attribute), f'Emulation "{emulation.name}" {error_msg}'

--- a/tests/test_emulations.py
+++ b/tests/test_emulations.py
@@ -1,0 +1,43 @@
+import pytest
+import warnings
+
+from swat.commands.base_command import BaseCommand
+from swat.emulations.base_emulation import BaseEmulation
+from swat.commands.emulate import Command as emulate_command
+
+
+class TestEmulations:
+    """Tests for emulations."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def emulations(self):
+        return emulate_command().load_all_emulation_classes()
+
+    def test_techniques(self, emulations):
+        errors = [f'Emulation "{emulation.name}" has no techniques defined' for emulation in emulations if not emulation.techniques]
+        assert not errors, '\n'.join(errors)
+
+    def test_services(self, emulations):
+        errors = [f'Emulation "{emulation.name}" has no services defined' for emulation in emulations if not emulation.services]
+        assert not errors, '\n'.join(errors)
+
+    def test_name(self, emulations):
+        errors = [f'Emulation "{emulation}" has no name defined' for emulation in emulations if not emulation.name]
+        assert not errors, '\n'.join(errors)
+
+    def test_scopes(self, emulations):
+        errors = [f'Emulation "{emulation.name}" has no scopes defined' for emulation in emulations if not emulation.scopes]
+        assert not errors, '\n'.join(errors)
+
+    def test_parser(self, emulations):
+        errors = [f'Emulation "{emulation.name}" has no parser defined' for emulation in emulations if not emulation.parser]
+        assert not errors, '\n'.join(errors)
+
+    def test_execute(self, emulations):
+        errors = [f'Emulation "{emulation.name}" has no execute method defined' for emulation in emulations if not emulation.execute]
+        assert not errors, '\n'.join(errors)
+
+    def test_cleanup(self, emulations):
+        warn_msgs = [f'Emulation "{emulation.name}" has no cleanup method defined' for emulation in emulations if not emulation.cleanup]
+        for msg in warn_msgs:
+            warnings.warn(msg)

--- a/tests/test_emulations.py
+++ b/tests/test_emulations.py
@@ -1,9 +1,10 @@
-import pytest
 import warnings
 
+import pytest
+
 from swat.commands.base_command import BaseCommand
-from swat.emulations.base_emulation import BaseEmulation
 from swat.commands.emulate import Command as emulate_command
+from swat.emulations.base_emulation import BaseEmulation
 
 
 class TestEmulations:
@@ -14,30 +15,30 @@ class TestEmulations:
         return emulate_command().load_all_emulation_classes()
 
     def test_techniques(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no techniques defined' for emulation in emulations if not emulation.techniques]
+        errors = [f'Emulation "{emulation.name}" has no techniques defined' for emulation in emulations if not hasattr(emulation, 'techniques')]
         assert not errors, '\n'.join(errors)
 
     def test_services(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no services defined' for emulation in emulations if not emulation.services]
+        errors = [f'Emulation "{emulation.name}" has no services defined' for emulation in emulations if not hasattr(emulation, 'services')]
         assert not errors, '\n'.join(errors)
 
     def test_name(self, emulations):
-        errors = [f'Emulation "{emulation}" has no name defined' for emulation in emulations if not emulation.name]
+        errors = [f'Emulation "{emulation}" has no name defined' for emulation in emulations if not hasattr(emulation, 'name')]
         assert not errors, '\n'.join(errors)
 
     def test_scopes(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no scopes defined' for emulation in emulations if not emulation.scopes]
+        errors = [f'Emulation "{emulation.name}" has no scopes defined' for emulation in emulations if not hasattr(emulation, 'scopes')]
         assert not errors, '\n'.join(errors)
 
     def test_parser(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no parser defined' for emulation in emulations if not emulation.parser]
+        errors = [f'Emulation "{emulation.name}" has no parser defined' for emulation in emulations if not hasattr(emulation, 'parser')]
         assert not errors, '\n'.join(errors)
 
     def test_execute(self, emulations):
-        errors = [f'Emulation "{emulation.name}" has no execute method defined' for emulation in emulations if not emulation.execute]
+        errors = [f'Emulation "{emulation.name}" has no execute method defined' for emulation in emulations if not hasattr(emulation, 'execute')]
         assert not errors, '\n'.join(errors)
 
     def test_cleanup(self, emulations):
-        warn_msgs = [f'Emulation "{emulation.name}" has no cleanup method defined' for emulation in emulations if not emulation.cleanup]
+        warn_msgs = [f'Emulation "{emulation.__module__}" has no cleanup method defined' for emulation in emulations if not hasattr(emulation, 'cleanup')]
         for msg in warn_msgs:
             warnings.warn(msg)


### PR DESCRIPTION
## Overview
This PR adds `pytest` as a dependency to SWAT. It also adds `test_emulation.py` with several tests regarding emulation module metadata that is required. This emulation metadata is used to dynamically determine, scopes, services, ATT&CK mappings and more which affect other features.

## Additional Information

- The `pyproject.toml` incorrectly pointed to `README.md`, this has been fixed.
- Added github workflow for pytest checks

## Testing

- _pytest_ addition: run `pytest`, `pytest tests/` or `poetry run pytest tests/`
- emulations missing metadata: find an emulations and remove `techniques`, `name`, `scopes`, `services` or `execute` method and run tests