### PR TITLE
[Emulation Tuning] Adjust 'Access Stored Keys and Tokens in Drive' Emulation

### DIFF
--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -12,6 +12,7 @@ Current (Unreleased)
 - Added `pytest` to the project and `test_emulation.py` for emulation tests. (`#71 <https://github.com/elastic/SWAT/pull/71>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 - Tuned `Add Admin Roles to User(s)` emulation and added admin directory `rolemanagement` and `user.security` to global scopes. (`#72 <https://github.com/elastic/SWAT/pull/72>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 - Tuned `Send HTML with Embedded Javascript with Gmail` emulation. (`#74 <https://github.com/elastic/SWAT/pull/74>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
+- Tuned `Access Stored Keys and Tokens in Drive` emulation. Replaced `Selenium` with `Requests`. (`#75 <https://github.com/elastic/SWAT/pull/75>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 
 [0.0.1] - 2023-08-12
 --------------------------

--- a/swat/emulations/collection/drive_access_private_keys.py
+++ b/swat/emulations/collection/drive_access_private_keys.py
@@ -18,18 +18,21 @@
 #
 
 import os
+import shutil
 import tempfile
 import time
-import shutil
 
+import requests
 from googleapiclient.discovery import build
 from googleapiclient.http import MediaFileUpload
 
 from swat.emulations.base_emulation import BaseEmulation
-from swat.utils import get_chromedriver
 
 
 class Emulation(BaseEmulation):
+    """
+    Stages text files with sensitive encryption key file extensions in Google Drive and accesses them via shared links.
+    """
     parser = BaseEmulation.load_parser(description='Stages sensitive encryption key files in Google Drive and accesses them via shared links.')
     parser.add_argument('session_key', default='default', help='Session to use for service building API service')
     parser.add_argument('folder_id', help='Google Drive Folder ID')
@@ -39,6 +42,8 @@ class Emulation(BaseEmulation):
     name = 'Access Stored Keys and Tokens in Drive'
     scopes = ['drive.file','drive.readonly','drive']
     services = ['drive']
+    description = "Stages sensitive encryption key files in Google Drive and accesses them via shared links."
+    references = ["https://github.com/elastic/detection-rules/blob/main/rules/integrations/google_workspace/credential_access_google_workspace_drive_encryption_key_accessed_by_anonymous_user.toml"]
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)
@@ -49,80 +54,92 @@ class Emulation(BaseEmulation):
             "token","assig", "pssc", "keystore", "pub", "pgp.asc", "ps1xml", "pem", "gpg.sig", "der", "key","p7r",
             "p12", "asc", "jks", "p7b", "signature", "gpg", "pgp.sig", "sst", "pgp", "gpgz", "pfx", "crt", "p8", "sig",
             "pkcs7", "jceks", "pkcs8", "psc1", "p7c", "csr", "cer", "spc", "ps2xml"
-        ][:5]  # TODO: why create a list and immediate slice it to 5?
+        ]
 
     def stage_files(self) -> list[str]:
         """Stage files in Google Drive and return a list of shareable links."""
-
         shareable_links = []
 
         for ext in self.file_extensions:
-            file_name = f"fake_file.{ext}"
-            file_content = f"This is a fake {file_name}"  # You can customize the content
+            try:
+                file_name = f"fake_file.{ext}"
+                file_content = f"This is a fake {file_name}"
 
-            # Write the content to a temporary file
-            with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-                temp_file.write(file_content.encode('utf-8'))
-                temp_path = temp_file.name
+                with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+                    temp_file.write(file_content.encode('utf-8'))
+                    temp_path = temp_file.name
 
-            # Use the temporary file path for MediaFileUpload
-            media = MediaFileUpload(temp_path, mimetype='text/plain', resumable=True)
-            file_metadata = self.service.files().create(media_body=media,
-                                                        body={'name': file_name, 'parents': [self.folder_id]}).execute()
-            os.unlink(temp_path)  # Delete the temporary file
+                media = MediaFileUpload(temp_path, mimetype='text/plain', resumable=True)
+                file_metadata = self.service.files().create(media_body=media,
+                                                            body={'name': file_name, 'parents': [self.folder_id]}).execute()
 
-            # Change file permission to allow anyone with the link to view
-            self.service.permissions().create(fileId=file_metadata['id'],
-                                            body={'role': 'reader', 'type': 'anyone'}).execute()
+                os.unlink(temp_path)
 
-            # Create a shareable link
-            shareable_link = f"https://drive.google.com/file/d/{file_metadata['id']}/view"
-            shareable_links.append(shareable_link)
+                self.service.permissions().create(fileId=file_metadata['id'],
+                                                body={'role': 'reader', 'type': 'anyone'}).execute()
 
-            self.elogger.info(f"Staged {file_name} with shareable link: {shareable_link}")
+                shareable_link = f"https://drive.google.com/file/d/{file_metadata['id']}/view"
+                shareable_links.append(shareable_link)
+
+                self.elogger.info(f"Staged {file_name} with shareable link: {shareable_link}")
+
+            except Exception as e:
+                self.elogger.error(f"Error while staging file with extension {ext}. Error: {str(e)}")
 
         return shareable_links
 
     def access_files(self, share_links) -> None:
         """Access the staged files via shared links and download them."""
 
-        self.elogger.info(f'Accessing staged files via shared links')
-        driver = get_chromedriver()
+        try:
+            self.elogger.info(f'Accessing staged files via shared links')
+            s = requests.Session()
+            s.headers.update({'User-Agent': 'Simple Workspace ATT&CK Tool (SWAT)'})
+            s.headers.update({'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'})
+            s.headers.update({'Accept-Encoding': 'gzip, deflate, br'})
+            s.headers.update({'Accept-Language': 'en-US,en;q=0.5'})
+            s.headers.update({'Connection': 'keep-alive'})
 
-        # Open each share link in Chrome and download the file
-        for link in share_links:
-            file_id = link.split('/')[-2]  # Extracting the file ID from the share link
-            # view the file
-            driver.get(link)
-            self.elogger.info(f"Accessed file at {link}")
-            # download the file
-            download_link = f"https://drive.google.com/uc?export=download&confirm=no_antivirus&id={file_id}"
-            driver.get(download_link)
-            self.elogger.info(f"Downloaded file from {download_link}")
-            time.sleep(1)  # You can modify the sleep time, or use WebDriverWait if needed
+            for link in share_links:
+                file_id = link.split('/')[-2]
+                s.get(link)
+                self.elogger.info(f"Accessed file at {link}")
+                download_link = f"https://drive.google.com/uc?export=download&confirm=no_antivirus&id={file_id}"
+                retrieved_file = s.get(download_link)
+                with open(f"{self.artifacts_path}/file_{file_id}", 'wb') as f:
+                    f.write(retrieved_file.content)
+                self.elogger.info(f"Downloaded file from {download_link}")
+                time.sleep(1)
 
-        # Close Chrome
-        driver.quit()
+            s.close()
+
+        except Exception as e:
+            self.elogger.error(f"Error accessing or downloading files. Error: {str(e)}")
 
     def cleanup(self) -> None:
         """Clean up staged files from Google Drive."""
-        # Query the files in the specified folder
-        results = self.service.files().list(q=f"'{self.folder_id}' in parents").execute()
-        files = results.get('files', [])
+        try:
+            results = self.service.files().list(q=f"'{self.folder_id}' in parents").execute()
+            files = results.get('files', [])
 
-        # Delete each file
-        for file in files:
-            self.service.files().delete(fileId=file['id']).execute()
-            self.elogger.info(f"Deleted {file['name']} from Google Drive")
+            for file in files:
+                self.service.files().delete(fileId=file['id']).execute()
+                self.elogger.info(f"Deleted {file['name']} from Google Drive")
 
-        # Delete local artifacts directory
-        shutil.rmtree(self.artifacts_path)
-        self.logger.info(f"Deleted local artifacts directory: {self.artifacts}")
+            shutil.rmtree(self.artifacts_path)
+            self.logger.info(f"Deleted local artifacts directory: {self.artifacts_path}")
+
+        except Exception as e:
+            self.elogger.error(f"Error during cleanup. Error: {str(e)}")
 
     def execute(self) -> None:
         """Main execution method."""
         self.elogger.info(self.exec_str(self.parser.description))
-        share_links = self.stage_files()
-        self.access_files(share_links)
-        if self.args.cleanup:
-            self.cleanup()
+        try:
+            share_links = self.stage_files()
+            self.access_files(share_links)
+            if self.args.cleanup:
+                self.cleanup()
+
+        except Exception as e:
+            self.elogger.error(f"Error during execution. Error: {str(e)}")


### PR DESCRIPTION
## Overview
This pull request makes adjustments to the `Access Stored Keys and Tokens in Drive` emulation.

- Removes the file extension list splicing so all file extensions are used. Originally this was added to set a limit to reduce time taken for emulation
- added `description` and `references` attributes to `Emulation` class
- added error handling to all methods
- removed access requests and file downloads from Selenium and Chrome to requests with sessions
- files are now downloaded to `swat/etc/artifacts/` after being staged

emulation log file: [collection_drive_access_private_keys.log](https://github.com/elastic/SWAT/files/12487227/collection_drive_access_private_keys.log)
note that these "private key" files are empty and the URLs are NULL including the folder ID within Google Workspace.

<img width="1948" alt="Screenshot 2023-08-31 at 10 47 48 AM" src="https://github.com/elastic/SWAT/assets/99630311/99df5c1f-f9c7-4009-978d-70d589379ee5">


