### PR TITLE
[Maintenance] Ignore local AI and planning markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 .vscode/
 .idea/
 
+# Local AI, planning, and development markdown.
+# Published project docs are RST. Keep only the markdown that ships with the repo.
+*.md
+!tango/README.md
+!.github/ISSUE_TEMPLATE/*.md
+
 # Mac/OSX
 .DS_Store
 


### PR DESCRIPTION
## Summary
- Ignore working `.md` files used for local AI, planning, and development notes.
- Keep published markdown tracked: `tango/README.md` and `.github/ISSUE_TEMPLATE/*.md`.

Official SWAT docs remain RST, so they are unaffected.

## Test plan
- [x] `git status` no longer lists local files such as `AGENT.md` or planning notes
- [x] `tango/README.md` and GitHub issue templates remain tracked
- [x] Existing RST docs are unchanged