### PR TITLE
[Maintenance] Record packaging updates and install from the lockfile in CI

### DIFF
--- a/.github/workflows/run_pytest.yml
+++ b/.github/workflows/run_pytest.yml
@@ -21,8 +21,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install poetry
-        poetry install
+        pip install poetry==2.3.3
+        poetry check --lock
+        poetry install --no-interaction
 
     - name: Run tests
       run: poetry run pytest tests/

--- a/docs/CHANGELOG.rst
+++ b/docs/CHANGELOG.rst
@@ -8,6 +8,9 @@ The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`
 Current (Unreleased)
 --------------------
 
+- Ignore local AI and planning markdown files. (`#90 <https://github.com/elastic/SWAT/pull/90>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
+- Pin Python dependencies to current 3.10-compatible versions and add ``poetry.lock``. (`#91 <https://github.com/elastic/SWAT/pull/91>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
+- Refresh ReadTheDocs requirements to the pinned Sphinx versions. (`#92 <https://github.com/elastic/SWAT/pull/92>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 - Initial start of the changelog documentation. (`#70 <https://github.com/elastic/SWAT/pull/70>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 - Added `pytest` to the project and `test_emulation.py` for emulation tests. (`#71 <https://github.com/elastic/SWAT/pull/71>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]
 - Tuned `Add Admin Roles to User(s)` emulation and added admin directory `rolemanagement` and `user.security` to global scopes. (`#72 <https://github.com/elastic/SWAT/pull/72>`_) [`@terrancedejesus <https://github.com/terrancedejesus>`_]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3.10",
     "Topic :: Security",
-    "Topic :: Google Workspace",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
## Summary
- Record #90, #91, and #92 in the unreleased changelog.
- Pin Poetry 2.3.3 in GitHub Actions and run `poetry check --lock` before `poetry install`.
- Remove the invalid `Topic :: Google Workspace` classifier so the lockfile check can succeed.

## Test plan
- [x] `poetry check --lock` exits 0
- [ ] CI pytest job installs from `poetry.lock` on Python 3.10
- [ ] Changelog entries for #90, #91, and #92 render on ReadTheDocs